### PR TITLE
update to use instal_kicker not install_qt_kicker

### DIFF
--- a/re_config.py
+++ b/re_config.py
@@ -6,7 +6,7 @@ import bluesky.plans as bp
 from bluesky.run_engine import RunEngine
 from bluesky.callbacks import best_effort
 from bluesky.simulators import summarize_plan
-from bluesky.utils import install_qt_kicker
+from bluesky.utils import install_kicker
 from bluesky.utils import ProgressBarManager
 
 import databroker
@@ -37,6 +37,6 @@ RE.subscribe(db.insert)
 db.reg.register_handler('srw', SRWFileHandler, overwrite=True)
 
 plt.ion()
-install_qt_kicker()
+install_kicker()
 
 _ = make_dir_tree(datetime.datetime.now().year, base_path='/tmp/data')


### PR DESCRIPTION
small change to use `install_kicker` instead of `install_qt_kicker`.

According to Tom when the bluesky master branch is next released we can remove this line completely but for now this resolves a plotting issue I was having!-)