### PR TITLE
Use mongodb backed databroker

### DIFF
--- a/re_config.py
+++ b/re_config.py
@@ -31,7 +31,7 @@ RE.subscribe(bec)
 #     pass
 
 # Temp sqlite backend:
-db = Broker.from_config(temp_config())
+db = Broker.named('local')
 
 RE.subscribe(db.insert)
 db.reg.register_handler('srw', SRWFileHandler, overwrite=True)


### PR DESCRIPTION
The sqlite backend causes some problems when trying to run a scan with arbitrary optical elements.